### PR TITLE
Split audio logging files using FileSink time-split support patch

### DIFF
--- a/darkice.cfg
+++ b/darkice.cfg
@@ -81,4 +81,16 @@ aim             = aim here  # AIM info related to the stream
 icq             = I see you too
                             # ICQ info related to the stream
 
-
+# this section describes saving to a local file
+# there may be up to 8 of these sections, named [file-0] ... [file-7]
+# these can be mixed with all other sections
+[file-0]
+channel         = 2             # channels to encode
+bitrateMode     = cbr           # constant bit rate mode
+format          = mp3           # format
+bitrate         = 256           # bitrate
+quality         = 0.9           # encoding quality
+duration        = 300           # split files into n-second chunks. 0 = infinite
+fileMode        = time          # 'duration' = break every n seconds
+                                # 'time' = break when time() % duration = 0
+fileName        = /log/%.mp3    # % character is replaced by the current timestamp

--- a/src/DarkIce.h
+++ b/src/DarkIce.h
@@ -148,7 +148,8 @@ class DarkIce : public virtual Referable, public virtual Reporter
          */
         void
         init (  const Config   & config )            throw ( Exception );
-
+	unsigned int
+	durationBytes (unsigned int dur);
         /**
          *  Look for the icecast stream outputs from the config file.
          *  Called from init()

--- a/src/FileSink.h
+++ b/src/FileSink.h
@@ -69,6 +69,10 @@ class FileSink : public Sink, public virtual Reporter
          */
         char      * fileName;
 
+	char	  * curFile;
+	bool	  macroExpand;
+	bool	  createFile;
+
         /**
          *  Initialize the object.
          *  
@@ -79,7 +83,8 @@ class FileSink : public Sink, public virtual Reporter
          */
         void
         init (  const char    * configName,
-                const char    * name )              throw ( Exception );
+                const char    * name,
+		bool macro, bool create )              throw ( Exception );
 
         /**
          *  De-initialize the object.
@@ -89,15 +94,11 @@ class FileSink : public Sink, public virtual Reporter
         void
         strip ( void )                              throw ( Exception );
 
-        /**
-         *  Get the file name to where to move the data saved so far.
-         *  Used in cut().
-         *
-         *  @return the file name where to move the data saved so far.
-         *  @throws Exception on file operation errors
-         */
-        std::string
-        getArchiveFileName( void )                  throw ( Exception );
+        char *
+        getFileName( void );
+
+	std::string
+	getArchiveFileName ( void )             throw ( Exception );
 
 
     protected:
@@ -131,9 +132,10 @@ class FileSink : public Sink, public virtual Reporter
          */
         inline
         FileSink(   const char        * configName,
-                    const char        * name )      throw ( Exception )
+                    const char        * name,
+		    bool macro, bool create )      throw ( Exception )
         {
-            init( configName, name);
+            init( configName, name, macro, create);
         }
 
         /**
@@ -166,24 +168,13 @@ class FileSink : public Sink, public virtual Reporter
         operator= ( const FileSink &    fs )        throw ( Exception );
 
         /**
-         *  Get the file name this FileSink represents.
-         *
-         *  @return the file name this FileSink represents.
-         */
-        inline const char *
-        getFileName ( void ) const                  throw ()
-        {
-            return fileName;
-        }
-
-        /**
          *  Check for the existence of the file this FileSink represents.
          *
          *  @return true if the file exists and is a regular file,
          *          false otherwise.
          */
         virtual bool
-        exists ( void ) const                       throw ();
+        exists ( void )                       throw ();
 
         /**
          *  Create the file.
@@ -255,7 +246,7 @@ class FileSink : public Sink, public virtual Reporter
          *  until now, and start saving a new chunk of data.
          */
         virtual void
-        cut ( void )                                    throw ();
+        cut ( void )				    throw ();
 
         /**
          *  Close the FileSink.

--- a/src/SinkLoop.h
+++ b/src/SinkLoop.h
@@ -1,0 +1,327 @@
+/*------------------------------------------------------------------------------
+
+   Copyright (c) 2000 Tyrell Corporation. All rights reserved.
+
+   Tyrell DarkIce
+
+   File     : SinkLoop.h
+   Version  : $Revision$
+   Author   : $Author$
+   Location : $Source$
+   
+   Copyright notice:
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License  
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+   
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of 
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+    GNU General Public License for more details.
+   
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+------------------------------------------------------------------------------*/
+#ifndef SINK_LOOP_H
+#define SINK_LOOP_H
+
+#ifndef __cplusplus
+#error This is a C++ include file
+#endif
+
+
+/* ============================================================ include files */
+
+#include "Sink.h"
+
+#include <stdio.h>
+
+
+/* ================================================================ constants */
+
+
+/* =================================================================== macros */
+
+
+/* =============================================================== data types */
+
+/**
+ *  Class representing a looping sink-forwarder
+ *
+ *  @author  $Author$
+ *  @version $Revision$
+ */
+class SinkLoop : public Sink
+{
+    private:
+
+        /**
+         *  The sink to pass the data to
+         */
+        Ref<Sink>       targetSink;
+
+	unsigned int limit;
+	unsigned int written;
+	//if seconds > 0 then break whenever time() % seconds == 0
+	unsigned int seconds;
+	int prevModulus;
+	int firstPass;
+
+        /**
+         *  Initalize the object.
+         *
+         *  @param targetSink the sink to pass the data to.
+         *  @exception Exception
+         */
+        inline void
+        init (  Sink          * targetSink,
+		    unsigned int  dataLimit,
+		    unsigned int  breakSeconds)
+                                                    throw ( Exception )
+        {
+            this->targetSink = targetSink;
+	        limit = dataLimit;
+	        if(limit <= 0) throw Exception(__FILE__,__LINE__);
+	        written = 0;
+	        seconds = breakSeconds;
+	        prevModulus = -1;
+	        firstPass = 1;
+        }
+
+        /**
+         *  De-initalize the object.
+         *
+         *  @exception Exception
+         */
+        inline void
+        strip ( void )                              throw ( Exception )
+        {
+            if ( isOpen() ) {
+                close();
+            }
+        }
+
+
+    protected:
+
+        /**
+         *  Default constructor. Always throws an Exception.
+         *
+         *  @exception Exception
+         */
+        inline
+        SinkLoop ( void )                            throw ( Exception )
+        {
+            throw Exception( __FILE__, __LINE__);
+        }
+
+
+    public:
+
+        /**
+         *  Constructor.
+         *
+         *  @param targetSink the sink to send all data to
+	     *  @param dataLimit the limit (in bytes) of data to be written 
+         *         before we start checking if the time is right 
+         *         (usually 3 seconds less than the time)
+	     *  @param breakSeconds Duration of clips in seconds, 
+         *         if non-zero breaks occur when time() % breakSeconds == 0
+         *  @exception Exception
+         */
+        inline
+        SinkLoop (  Sink          * targetSink,
+		    unsigned int  dataLimit,
+		    unsigned int  breakSeconds)
+                                                        throw ( Exception )
+                : Sink()
+        {
+            init( targetSink,dataLimit,breakSeconds );
+        }
+
+        /**
+         *  Constructor.
+         *
+         *  @param targetSink the sink to send all data to
+	     *  @param dataLimit the limit (in bytes) of data to be written
+         *  @exception Exception
+         */
+        inline
+        SinkLoop (  Sink          * targetSink,
+		    unsigned int  dataLimit )
+                                                        throw ( Exception )
+                : Sink()
+        {
+            init( targetSink,dataLimit,0 );
+        }
+
+        /**
+         *  Copy constructor.
+         *
+         *  @param cs the SinkLoop to copy.
+         */
+        inline
+        SinkLoop(   const SinkLoop &    cs )        throw ( Exception )
+        {
+            init( cs.targetSink.get(),cs.limit,cs.seconds );
+        }
+
+        /**
+         *  Destructor.
+         *
+         *  @exception Exception
+         */
+        inline virtual
+        ~SinkLoop( void )                           throw ( Exception )
+        {
+            strip();
+        }
+
+        /**
+         *  Assignment operator.
+         *
+         *  @param cs the SinkLoop to assign this to.
+         *  @return a reference to this SinkLoop.
+         *  @exception Exception
+         */
+        inline virtual SinkLoop &
+        operator= ( const SinkLoop &    cs )        throw ( Exception )
+        {
+            if ( this != &cs ) {
+                strip();
+                init( cs.targetSink.get(),cs.limit,cs.seconds );
+            }
+            return *this;
+        }
+
+        /**
+         *  Open the SinkLoop.
+         *
+         *  @return true if opening was successfull, false otherwise.
+         *  @exception Exception
+         */
+        inline virtual bool
+        open ( void )                               throw ()
+	    {
+	        if(isOpen()) {
+		        flush();
+	            targetSink->close();
+	        }
+	    
+            //On the first pass we should be checking time() constantly
+	        //so that we're aligned to start with, so make it look like
+	        //we've already written enough to hit the limit...
+	        if(firstPass && seconds > 0)
+		        written = limit +1;
+	        else
+		        written = 0;
+	        firstPass = 0;
+	        prevModulus = -1;
+	        return targetSink->open();
+	    }
+
+        /**
+         *  Check if the SinkLoop is open.
+         *
+         *  @return true if the target sink is open, false otherwise.
+         */
+        inline virtual bool
+        isOpen ( void ) const                       throw ()
+        {
+            return targetSink->isOpen();
+        }
+
+        /**
+         *  Check if the SinkLoop is ready to accept data.
+         *  Blocks until the specified time for data to be available.
+         *
+         *  @param sec the maximum seconds to block.
+         *  @param usec micro seconds to block after the full seconds.
+         *  @return true if the SinkLoop is ready to accept data,
+         *          false otherwise.
+         *  @exception Exception
+         */
+        inline virtual bool
+        canWrite (     unsigned int    sec,
+                       unsigned int    usec )       throw ( Exception )
+        {
+	    /*No need to check here, since we check after every write,
+	     *should never get here with written >= limit..
+	     */
+	    return targetSink->canWrite( sec, usec);
+		
+        }
+
+        /**
+         *  Write data to the SinkLoop.
+         *
+         *  @param buf the data to write.
+         *  @param len number of bytes to write from buf.
+         *  @return the number of bytes written (may be less than len).
+         *  @exception Exception
+         */
+        inline virtual unsigned int
+        write (        const void    * buf,
+                       unsigned int    len )        throw ( Exception )
+        {
+            unsigned int ret = targetSink->write( buf, len);
+	        written += ret;
+	        if(written >= limit) {
+		        if(seconds > 0)	{
+		            int modulus = time(NULL) % seconds;
+		            if(modulus < prevModulus) {
+			            open();
+		            } else {
+			            prevModulus = modulus;
+                    }
+		        } else {
+		            //Force a close & re-open
+		            open();
+                }
+	        }
+	    return ret;
+        }
+
+        /**
+         *  Flush all data that was written to the SinkLoop to the server.
+         *
+         *  @exception Exception
+         */
+        inline virtual void
+        flush ( void )                              throw ( Exception )
+        {
+            return targetSink->flush();
+        }
+
+        /**
+         *  Close the SinkLoop.
+         *
+         *  @exception Exception
+         */
+        inline virtual void
+        close ( void )                              throw ( Exception )
+        {
+	        firstPass =1;
+            return targetSink->close();
+        }
+
+	    inline virtual void
+	    cut ( void )				    throw ()
+	    {
+	        return targetSink->cut();
+	    }
+};
+
+
+/* ================================================= external data structures */
+
+
+/* ====================================================== function prototypes */
+
+
+
+#endif  /* FILE_CAST_H */


### PR DESCRIPTION
> About 10 years ago one of my predecessors at the student radio station I volunteer for forked this code and added a SinkLoop element to the FileSink so darkice would automatically split the log files every 'n' seconds.  We have been using this ever since to save our station output as a series of 5-minute MP3 files on our logging server, accessing these logs via a web service which cuts/adds headers as necessary to create files of any length (in 5-minute multiples).
> 
> I have now updated this code to the latest SVN revision of darkice 1.2 and added in some extra configuration options, and I think many people would find it useful if it were integrated into the core!

Original issue reported on code.google.com by jontysewell on 18 May 2013 at 6:33
https://code.google.com/p/darkice/issues/detail?id=88
